### PR TITLE
ScreenOS parsing bug

### DIFF
--- a/NetScreenMigration/ScreenOSCommands.cs
+++ b/NetScreenMigration/ScreenOSCommands.cs
@@ -70,7 +70,7 @@ namespace NetScreenMigration
                         do
                         {
                             tempArrayList[i] += " " + tempArrayList[i + 1];
-                            tempArrayList.Remove(tempArrayList[i + 1]);
+                            tempArrayList.RemoveAt(i + 1);
                         } while (tempArrayList[i].Last() != '\"' && i + 1 < tempArrayList.Count);
                     }
                 }


### PR DESCRIPTION
Changed to remove by index vs. by value.  Current method will remove on first match and causes errors when a word is duplicated.

Example:  
`set policy id 10 from "inside" to "management" "Inside_nets" "Mgmt_nets" "Inside_nets to Mgmt_nets" permit`

