### PR TITLE
SmartMove updates

### DIFF
--- a/CheckPointObjects/RuleBaseOptimizer.cs
+++ b/CheckPointObjects/RuleBaseOptimizer.cs
@@ -17,6 +17,8 @@ limitations under the License.
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using CommonUtils;
 
 namespace CheckPointObjects
@@ -56,6 +58,11 @@ namespace CheckPointObjects
                 }
 
                 curLayer = nextLayer;
+            }
+
+            for (int i = 0; i < newLayer.Rules.Count; ++i)
+            {
+                newLayer.Rules[i].ConversionComments = OptimizeConverstionComments(newLayer.Rules[i].ConversionComments);
             }
 
             return newLayer;
@@ -209,6 +216,30 @@ namespace CheckPointObjects
             var secondNotFirst = list2.Except(list1).ToList();
 
             return (!firstNotSecond.Any() && !secondNotFirst.Any());
+        }
+
+        /// <summary>
+        /// Method for creation comment by the template 'optimized of access-list #x #y'
+        /// </summary>
+        /// <param name="commentToProcess">comment to process</param>
+        /// <returns>optimized comment at the right format</returns>
+        private static string OptimizeConverstionComments(string commentToProcess)
+        {
+            string commentBuilder = "optimized of access-list";
+            List<string> rules = new List<string>();
+            List<string> comments_parts = commentToProcess.Split(' ').ToList();
+            Regex regex = new Regex(@"[0-9]+[)]");
+
+            if (regex.IsMatch(comments_parts[0]))
+                foreach (string part in comments_parts)
+                {
+                    if (regex.IsMatch(part))
+                        commentBuilder += " " + part.Remove(part.Length - 1);
+                }
+            else
+                return commentToProcess;
+
+            return commentBuilder;
         }
     }
 }

--- a/CheckPointObjects/RuleBaseOptimizer.cs
+++ b/CheckPointObjects/RuleBaseOptimizer.cs
@@ -91,6 +91,7 @@ namespace CheckPointObjects
                 CheckPoint_Rule rule = newRule.Clone();
                 rule.Layer = layer.Name;
                 rule.Comments = "";
+                rule.ConversionComments = newRule.ConversionComments;
                 layer.Rules.Add(rule);
             }
         }
@@ -131,6 +132,7 @@ namespace CheckPointObjects
             mergedRule.SourceNegated = rule1.SourceNegated;
             mergedRule.DestinationNegated = rule1.DestinationNegated;
             mergedRule.Comments = "";
+            mergedRule.ConversionComments = rule1.ConversionComments + " | " + rule2.ConversionComments;
             mergedRule.ConvertedCommandId = rule1.ConvertedCommandId;
             mergedRule.ConversionIncidentType = ConversionIncidentType.None;
 

--- a/CiscoMigration/CiscoCommands.cs
+++ b/CiscoMigration/CiscoCommands.cs
@@ -264,6 +264,11 @@ namespace CiscoMigration
         }
     }
 
+    public class FirePower : Cisco_ASA
+    {
+        public override string Name() { return "NGFW"; }
+    }
+
     public class Cisco_Alias : CiscoCommand
     {
         public override string Name() { return "name"; }

--- a/CiscoMigration/CiscoConverter.cs
+++ b/CiscoMigration/CiscoConverter.cs
@@ -4640,6 +4640,7 @@ namespace CiscoMigration
                     newRule.SubPolicyName = regular2OptimizedLayers[rule.SubPolicyName];
                 }
                 newRule.Layer = optimizedPackage.ParentLayer.Name;
+                newRule.ConversionComments = rule.ConversionComments;
 
                 optimizedPackage.ParentLayer.Rules.Add(newRule);
             }

--- a/CiscoMigration/CiscoConverter.cs
+++ b/CiscoMigration/CiscoConverter.cs
@@ -36,6 +36,9 @@ namespace CiscoMigration
     /// </summary>
     public class CiscoConverter : VendorConverter
     {
+        //if we are using cisco code for fire power vendor we need set this flag to true value
+        public bool isUsingForFirePower { get; set; } = false;
+
         #region Helper Classes
 
         private class DuplicateNameInfo
@@ -624,7 +627,11 @@ namespace CiscoMigration
         {
             if (base.AddCheckPointObject(cpObject))
             {
-                string vendor = Vendor.CiscoASA.ToString();
+                string vendor;
+                if (isUsingForFirePower)
+                    vendor = Vendor.FirePower.ToString();
+                else
+                    vendor = Vendor.CiscoASA.ToString();
                 if (!cpObject.Tags.Contains(vendor))
                 {
                     cpObject.Tags.Add(vendor);

--- a/CiscoMigration/CiscoParser.cs
+++ b/CiscoMigration/CiscoParser.cs
@@ -31,6 +31,9 @@ namespace CiscoMigration
     /// </summary>
     public class CiscoParser : VendorParser
     {
+        //if we are using cisco code for fire power vendor we need set this flag to true value
+        public bool isUsingForFirePower { get; set; } = false;
+
         #region Helper Classes
 
         private class Indentation
@@ -62,7 +65,10 @@ namespace CiscoMigration
         public override void Parse(string filename)
         {
             ParseCommands(filename);   // this must come first!!!
-            ParseVersion(null);
+            if (isUsingForFirePower)
+                ParseVersion("NGFW");
+            else
+                ParseVersion(null);
             ParseInterfacesTopology();
         }
 
@@ -112,9 +118,21 @@ namespace CiscoMigration
 
         protected override void ParseVersion(object versionProvider)
         {
-            foreach (Cisco_ASA asa in Filter("ASA"))
+            if (versionProvider != null)
             {
-                VendorVersion = asa.Version;
+                //FirePower
+                string allowedVersionType = (string)versionProvider;
+                foreach (FirePower asa in Filter(allowedVersionType))
+                {
+                    VendorVersion = asa.Version;
+                }
+            }
+            else
+            {
+                foreach (Cisco_ASA asa in Filter("ASA"))
+                {
+                    VendorVersion = asa.Version;
+                }
             }
         }
 

--- a/FortinetMigration/FortiGateParser.cs
+++ b/FortinetMigration/FortiGateParser.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Newtonsoft.Json;
 using MigrationBase;
+using System.Text;
 
 namespace FortiGateMigration
 {
@@ -44,7 +45,7 @@ namespace FortiGateMigration
 
         private void ParseCommands(string filename)
         {
-            string[] linesCfg = File.ReadAllLines(filename);
+            string[] linesCfg = File.ReadAllLines(filename, Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback(""), new DecoderReplacementFallback("")));
 
             Stack<FgCommandExt> stackFgCommands = new Stack<FgCommandExt>();
 

--- a/FortinetMigration/FortiGateParser.cs
+++ b/FortinetMigration/FortiGateParser.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using Newtonsoft.Json;
 using MigrationBase;
-using System.Text;
 
 namespace FortiGateMigration
 {
@@ -45,7 +44,7 @@ namespace FortiGateMigration
 
         private void ParseCommands(string filename)
         {
-            string[] linesCfg = File.ReadAllLines(filename, Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback(""), new DecoderReplacementFallback("")));
+            string[] linesCfg = File.ReadAllLines(filename);
 
             Stack<FgCommandExt> stackFgCommands = new Stack<FgCommandExt>();
 

--- a/MigrationBase/SupportedVendors.cs
+++ b/MigrationBase/SupportedVendors.cs
@@ -67,7 +67,9 @@ namespace MigrationBase
     public enum Vendor
     {
         [Description("Cisco ASA")]
-        CiscoASA,
+        CiscoASA, 
+        [Description("FirePower")]
+        FirePower,
         [Description("Juniper JunosOS SRX")]
         JuniperJunosOS,
         [Description("Juniper ScreenOS SSG/ISG/NS")]

--- a/SmartMove/CommandLine.cs
+++ b/SmartMove/CommandLine.cs
@@ -112,7 +112,7 @@ namespace SmartMove
             Console.WriteLine("\t" + "-s | --source" + "\t\t" + "full path to the vendor configuration file");
             Console.WriteLine("\t" + "-v | --vendor" + "\t\t" + "vendor for conversion (available options: CiscoASA, FirePower, JuniperSRX, JuniperSSG, FortiNet, PaloAlto, Panorama)");
             Console.WriteLine("\t" + "-t | --target" + "\t\t" + "migration output folder");
-            Console.WriteLine("\t" + "-d | --domain" + "\t\t" + "domain name (for CiscoASA, JuniperSRX, JuniperSSG only)");
+            Console.WriteLine("\t" + "-d | --domain" + "\t\t" + "domain name (for CiscoASA, FirePower, JuniperSRX, JuniperSSG only)");
             Console.WriteLine("\t" + "-n | --nat" + "\t\t" + @"(""-n false"" |"" -n true"" [default])  convert NAT configuration [enabled by default]");
             Console.WriteLine("\t" + "-l | --ldap" + "\t\t" + "LDAP Account unit for convert user configuration option (for FortiNet, PaloAlto and Panorama only)");
             Console.WriteLine("\t" + "-k | --skip" + "\t\t" + @"(""-k false"" |"" -k true"" [default]) do not import unused objects (for FortiNet, PaloAlto and Panorama only) [enabled by default]");
@@ -131,7 +131,7 @@ namespace SmartMove
         public int CheckOptionsValidity(CommandLine commandLine)
         {
             var fullVendorsList = new List<string> { "CiscoASA", "JuniperSRX", "JuniperSSG", "FortiNet", "PaloAlto", "Panorama", "FirePower" };
-            var vendorsList1 = new List<string> { "CiscoASA", "JuniperSRX", "JuniperSSG" };
+            var vendorsList1 = new List<string> { "CiscoASA", "JuniperSRX", "JuniperSSG", "FirePower" };
             var vendorsList2 = new List<string> { "FortiNet", "PaloAlto", "Panorama" };
             if (String.IsNullOrEmpty(commandLine.Vendor))
             {

--- a/SmartMove/CommandLine.cs
+++ b/SmartMove/CommandLine.cs
@@ -100,6 +100,8 @@ namespace SmartMove
 
         private bool _successCommands = true;
         private bool _isInteractive = true;
+
+        private bool _isCiscoSpreadAclRemarks = false;
         #endregion
 
         public int DisplayHelp()
@@ -422,6 +424,22 @@ namespace SmartMove
                             }
                             break;
                         }
+                    case "--asa-spread-acl-remarks":
+                        {
+                            if (args[i] == args.Last())
+                            {
+                                _successCommands = false;
+                                Console.WriteLine("Value for option --asa-spread-acl-remarks is not specified! ", MessageTypes.Error);
+                            }
+                            else if (bool.TryParse(args[i + 1].ToLower(), out _isCiscoSpreadAclRemarks))
+                                break;
+                            else
+                            {
+                                _successCommands = false;
+                                Console.WriteLine("Value for option format is not corrected! Allow only 'text' or 'json' ", MessageTypes.Error);
+                            }
+                            break;
+                        }
                 }
             }
             return this;
@@ -500,6 +518,7 @@ namespace SmartMove
             switch (commandLine.Vendor)
             {
                 case "CiscoASA":
+                    CiscoParser.SpreadAclRemarks = _isCiscoSpreadAclRemarks;
                     vendorParser = new CiscoParser();
                     break;
                 case "FirePower":

--- a/SmartMove/CommandLine.cs
+++ b/SmartMove/CommandLine.cs
@@ -436,7 +436,7 @@ namespace SmartMove
                             else
                             {
                                 _successCommands = false;
-                                Console.WriteLine("Value for option format is not corrected! Allow only 'text' or 'json' ", MessageTypes.Error);
+                                Console.WriteLine("Value for option format is not corrected! Allow only 'true' or 'false' ", MessageTypes.Error);
                             }
                             break;
                         }

--- a/SmartMove/MainWindow.xaml.cs
+++ b/SmartMove/MainWindow.xaml.cs
@@ -441,6 +441,11 @@ namespace SmartMove
                 case Vendor.CiscoASA:
                     vendorParser = new CiscoParser();
                     break;
+                case Vendor.FirePower:
+                    vendorParser = new CiscoParser() { 
+                        isUsingForFirePower = true 
+                    };
+                    break;
                 case Vendor.JuniperJunosOS:
                     vendorParser = new JuniperParser();
                     break;
@@ -523,6 +528,19 @@ namespace SmartMove
                     }
                     break;
 
+                case Vendor.FirePower:
+                    if (string.IsNullOrEmpty(vendorParser.Version))
+                    {
+                        ShowMessage("Unspecified NGFW version.\nCannot find version for the selected configuration.\nThe configuration may not parse correctly.", MessageTypes.Warning);
+                        return;
+                    }
+                    else if (vendorParser.MajorVersion < 6 || (vendorParser.MajorVersion == 6 && vendorParser.MinorVersion < 4))
+                    {
+                        ShowMessage("Unsupported version (" + vendorParser.Version + ").\nThis tool supports NGFW 6.4 and above configuration files.\nThe configuration may not parse correctly.", MessageTypes.Warning);
+                        return;
+                    }
+                    break;
+
                 case Vendor.JuniperJunosOS:
                     if (string.IsNullOrEmpty(vendorParser.Version))
                     {
@@ -585,6 +603,11 @@ namespace SmartMove
             {
                 case Vendor.CiscoASA:
                     vendorConverter = new CiscoConverter();
+                    break;
+                case Vendor.FirePower:
+                    vendorConverter = new CiscoConverter() {
+                        isUsingForFirePower = true
+                    };
                     break;
                 case Vendor.JuniperJunosOS:
                     vendorConverter = new JuniperConverter();

--- a/SmartMove/SmartConnector/smartconnector.py
+++ b/SmartMove/SmartConnector/smartconnector.py
@@ -5,9 +5,7 @@ import argparse
 import json
 import os
 import re
-import string
-import random
-import time
+import operator
 import uuid
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
@@ -127,10 +125,11 @@ def isServerObjectLocal(serverObject):
 # client - client object
 # apiCommand - short string which indicates what should be done
 # payload - JSON representation of "new" object
+# userObjectNamePostfix - postfix as number
 # changeName=True - True: to try to add object and adjust the name; False: to try to add object and NOT adjust the name
 # ---
 # returns: added object from server in JSON format, None - otherwise
-def addUserObjectToServer(client, apiCommand, payload, hash: str, changeName=True):
+def addUserObjectToServer(client, apiCommand, payload, userObjectNamePostfix=1, changeName=True):
     isObjectAdded = False
     userObjectNameInitial = ""
     if changeName:
@@ -143,7 +142,8 @@ def addUserObjectToServer(client, apiCommand, payload, hash: str, changeName=Tru
             if not changeName:
                 break
             if isNameDuplicated(res_add_obj):
-                payload['name'] = userObjectNameInitial + '_' + hash
+                payload['name'] = userObjectNameInitial + '_' + str(userObjectNamePostfix)
+                userObjectNamePostfix += 1
             else:
                 break
         else:
@@ -154,7 +154,7 @@ def addUserObjectToServer(client, apiCommand, payload, hash: str, changeName=Tru
 
 # adding to server the object which contains fields with IP: hosts, networks
 # adjusting the name if object with the name exists at server: <initial_object_name>_<postfix>
-# using the object from server side if object exsits with the same IP at server
+# using the object from server side if object exits with the same IP at server
 # client - client object
 # payload - JSON representation of "new" object
 # userObjectType - the type of object: host or network
@@ -162,43 +162,55 @@ def addUserObjectToServer(client, apiCommand, payload, hash: str, changeName=Tru
 # mergedObjectsNamesMap - the map which contains name of user's object (key) and name of resulting object (value)
 # ---
 # returns: updated mergedObjectsNamesMap
-def addCpObjectWithIpToServer(client, payload, userObjectType, userObjectIp, mergedObjectsNamesMap, hash: str):
+def addCpObjectWithIpToServer(client, payload, userObjectType, userObjectIp, mergedObjectsNamesMap):
     printStatus(None, "processing " + userObjectType + ": " + payload['name'])
     userObjectNameInitial = payload['name']
+    userObjectNamePostfix = 1
     isFinished = False
     isIgnoreWarnings = False
     while not isFinished:
         payload["ignore-warnings"] = isIgnoreWarnings
+        # payload["--user-agent"] = "mgmt_cli_smartmove";
         res_add_obj_with_ip = client.api_call("add-" + userObjectType, payload)
+        print("add-" + userObjectType, payload)
         printStatus(res_add_obj_with_ip, "REPORT: " + userObjectNameInitial + " is added as " + payload['name'])
         if res_add_obj_with_ip.success is False:
             if isIpDuplicated(res_add_obj_with_ip) and not isIgnoreWarnings:
-                res_get_obj_with_ip = client.api_query("show-objects", payload={"filter": userObjectIp, "ip-only": True, "type": userObjectType})
+                res_get_obj_with_ip = client.api_query("show-objects", payload={"filter": userObjectIp, "ip-only": True,
+                                                                                "type": userObjectType})
                 printStatus(res_get_obj_with_ip, None)
                 if res_get_obj_with_ip.success is True:
                     if len(res_get_obj_with_ip.data) > 0:
-                        if userObjectType == "network" and next((x for x in res_get_obj_with_ip.data if x['subnet4' if is_valid_ipv4(payload['subnet']) else 'subnet6'] == payload['subnet']), None) is None:
+                        if userObjectType == "network" and next((x for x in res_get_obj_with_ip.data if x[
+                                                                                                            'subnet4' if is_valid_ipv4(
+                                                                                                                    payload[
+                                                                                                                        'subnet']) else 'subnet6'] ==
+                                                                                                        payload[
+                                                                                                            'subnet']),
+                                                                None) is None:
                             isIgnoreWarnings = True
                         else:
                             if userObjectType == "host":
                                 mergedObjectsNamesMap[userObjectNameInitial] = res_get_obj_with_ip.data[0]['name']
-                                printStatus(None, "REPORT: " + "CP object " + mergedObjectsNamesMap[userObjectNameInitial] + " is used instead of " + userObjectNameInitial)
+                                printStatus(None, "REPORT: " + "CP object " + mergedObjectsNamesMap[
+                                    userObjectNameInitial] + " is used instead of " + userObjectNameInitial)
                                 isFinished = True
                             break
-                            '''
                             for serverObject in res_get_obj_with_ip.data:
                                 mergedObjectsNamesMap[userObjectNameInitial] = serverObject['name']
-                                if (isServerObjectLocal(serverObject) and not isReplaceFromGlobalFirst) or (isServerObjectGlobal(serverObject) and isReplaceFromGlobalFirst):
+                                if (isServerObjectLocal(serverObject) and not isReplaceFromGlobalFirst) or (
+                                        isServerObjectGlobal(serverObject) and isReplaceFromGlobalFirst):
                                     break
-                            printStatus(None, "REPORT: " + "CP object " + mergedObjectsNamesMap[userObjectNameInitial] + " is used instead of " + userObjectNameInitial)
+                            printStatus(None, "REPORT: " + "CP object " + mergedObjectsNamesMap[
+                                userObjectNameInitial] + " is used instead of " + userObjectNameInitial)
                             isFinished = True
-                            '''
                     else:
                         isIgnoreWarnings = True
                 else:
                     isFinished = True
             elif isNameDuplicated(res_add_obj_with_ip):
-                payload['name'] = userObjectNameInitial + '_' + hash
+                payload['name'] = userObjectNameInitial + '_' + str(userObjectNamePostfix)
+                userObjectNamePostfix += 1
             else:
                 isFinished = True
         else:
@@ -216,34 +228,33 @@ def addCpObjectWithIpToServer(client, payload, userObjectType, userObjectIp, mer
 # mergedGroupsNamesMap - the map which contains name of user's object (key) and name of resulting object (value)
 # ---
 # returns: updated mergedGroupsNamesMap
-def processGroupWithMembers(client, apiCommand, userGroup, isNeedSplitted, hash: str):
+def processGroupWithMembers(client, apiCommand, userGroup, mergedObjectsMap, mergedGroupsNamesMap, isNeedSplitted):
     apiSetCommand = "set-group"
     addedGroup = None
     if "time" in apiCommand:
         apiSetCommand = "set-time-group"
     elif "service" in apiCommand:
         apiSetCommand = "set-service-group"
-    
-    if isNeedSplitted and "Members" in userGroup.keys():
+
+    if isNeedSplitted:
         for i, userGroupMember in enumerate(userGroup['Members']):
             print(userGroupMember)
             res_add_obj = client.api_call(
                 apiSetCommand,
                 {
-                    "name": userGroup['Name'],                    
-                    "members": { "add" : userGroupMember }
+                    "name": userGroup['Name'],
+                    "members": {"add": userGroupMember}
                 })
-            printStatus(None, "REPORT: " + userGroup['Name'] + " is setted with new member " + str(userGroupMember))
+            printStatus(None, "REPORT: " + userGroup['Name'] + " is set with new member " + str(userGroupMember))
     else:
         addedGroup = addUserObjectToServer(
             client,
             apiCommand,
             {
-            "name": userGroup['Name'],
-            "comments": userGroup['Comments'],
-            "tags": userGroup['Tags']
-            },
-            hash
+                "name": userGroup['Name'],
+                "comments": userGroup['Comments'],
+                "tags": userGroup['Tags']
+            }
         )
     return addedGroup
 
@@ -255,27 +266,15 @@ def processGroupWithMembers(client, apiCommand, userGroup, isNeedSplitted, hash:
 # ---
 # returns: mergedDomainsNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processDomains(client, userDomains, hash: str):
+def processDomains(client, userDomains):
     printMessageProcessObjects("domains...")
     publishCounter = 0
     mergedDomainsNamesMap = {}
     if len(userDomains) == 0:
         return mergedDomainsNamesMap
-
-    serverDomainNames = []
-    res_get_domains = client.api_query("show-dns-domains")
-    for domain in res_get_domains.data:
-        serverDomainNames.append(domain['name'])
-
     for userDomain in userDomains:
         userDomainNameInitial = userDomain['Name']
         printStatus(None, "processing domain: " + userDomain['Name'])
-
-        if userDomain['Name'] in serverDomainNames:
-            printStatus(None, None, 'This domain exists on the server')
-            mergedDomainsNamesMap[userDomainNameInitial] = userDomain['Name']
-            continue
-
         addedDomain = addUserObjectToServer(
             client,
             "add-dns-domain",
@@ -284,8 +283,7 @@ def processDomains(client, userDomains, hash: str):
                 "is-sub-domain": userDomain['IsSubDomain'],
                 "comments": userDomain['Comments'],
                 "tags": userDomain['Tags']
-            },
-            hash
+            }
         )
         if addedDomain is not None:
             mergedDomainsNamesMap[userDomainNameInitial] = addedDomain['name']
@@ -306,29 +304,13 @@ def processDomains(client, userDomains, hash: str):
 # ---
 # returns: mergedHostsNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processHosts(client, userHosts, hash: str):
+def processHosts(client, userHosts):
     printMessageProcessObjects("hosts")
     publishCounter = 0
     mergedHostsNamesMap = {}
     if len(userHosts) == 0:
         return mergedHostsNamesMap
-
-    host_ipv4_names = []
-    host_ipv6_names = []
-    res_get_hosts = client.api_query("show-hosts")
-    for host in res_get_hosts.data:
-        if 'ipv4-address' in host.keys() and host['ipv4-address']:
-            host_ipv4_names.append(host['name'] + host['ipv4-address'])
-        if 'ipv6-address' in host.keys() and host['ipv6-address']:
-            host_ipv6_names.append(host['name'] + host['ipv6-address'])
-
     for userHost in userHosts:
-        key = userHost['Name'] + userHost['IpAddress']
-        if key in host_ipv4_names or key in host_ipv6_names:
-            printStatus(None, None, 'This host exists on the server')
-            mergedHostsNamesMap[userHost['Name']] = userHost['Name']
-            continue
-
         payload = {
             "name": userHost['Name'],
             "ip-address": userHost['IpAddress'],
@@ -337,7 +319,7 @@ def processHosts(client, userHosts, hash: str):
         }
         initialMapLength = len(mergedHostsNamesMap)
         mergedHostsNamesMap = addCpObjectWithIpToServer(client, payload, "host", userHost['IpAddress'],
-                                                        mergedHostsNamesMap, hash)
+                                                        mergedHostsNamesMap)
         if initialMapLength == len(mergedHostsNamesMap):
             printStatus(None, "REPORT: " + userHost['Name'] + ' is not added.')
         else:
@@ -384,6 +366,7 @@ def is_valid_ipv4(ip):
     """, re.VERBOSE | re.IGNORECASE)
     return pattern.match(ip) is not None
 
+
 def is_valid_ipv6(ip):
     pattern = re.compile(r"""
         ^
@@ -413,6 +396,7 @@ def is_valid_ipv6(ip):
     """, re.VERBOSE | re.IGNORECASE | re.DOTALL)
     return pattern.match(ip) is not None
 
+
 # processing and adding to server the CheckPoint Networks
 # adjusting the name if network with the name exists at server: <initial_object_name>_<postfix>
 # if network contains existing IP subnet then Network object from server will be used instead
@@ -421,30 +405,14 @@ def is_valid_ipv6(ip):
 # ---
 # returns: mergedNetworksNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processNetworks(client, userNetworks, hash: str):
+def processNetworks(client, userNetworks):
     printMessageProcessObjects("networks")
     publishCounter = 0
     mergedNetworksNamesMap = {}
-    userNetworks = sorted(userNetworks, key=lambda K: (K['Netmask'], K['MaskLength']) , reverse=True)
+    userNetworks = sorted(userNetworks, key=lambda K: (K['Netmask'], K['MaskLength']), reverse=True)
     if len(userNetworks) == 0:
         return mergedNetworksNamesMap
-
-    serverNetworkSubnet4Names = []
-    serverNetworkSubnet6Names = []
-    res_get_networks = client.api_query("show-networks")
-    for network in res_get_networks.data:
-        if 'subnet4' in network.keys() and network['subnet4']:
-            serverNetworkSubnet4Names.append(network['name'] + network['subnet4'])
-        if 'subnet6' in network.keys() and network['subnet6']:
-            serverNetworkSubnet6Names.append(network['name'] + network['subnet6'])
-
     for userNetwork in userNetworks:
-        key = userNetwork['Name'] + userNetwork['Subnet']
-        if key in serverNetworkSubnet4Names or key in serverNetworkSubnet6Names:
-            printStatus(None, None, 'This network exists on the server')
-            mergedNetworksNamesMap[userNetwork['Name']] = userNetwork['Name']
-            continue
-
         payload = {
             "name": userNetwork['Name'],
             "comments": userNetwork['Comments'],
@@ -456,7 +424,8 @@ def processNetworks(client, userNetworks, hash: str):
         else:
             payload["mask-length6"] = userNetwork['MaskLength']
         initialMapLength = len(mergedNetworksNamesMap)
-        mergedNetworksNamesMap = addCpObjectWithIpToServer(client, payload, "network", userNetwork['Subnet'], mergedNetworksNamesMap, hash)
+        mergedNetworksNamesMap = addCpObjectWithIpToServer(client, payload, "network", userNetwork['Subnet'],
+                                                           mergedNetworksNamesMap)
         if initialMapLength == len(mergedNetworksNamesMap):
             printStatus(None, "REPORT: " + userNetwork['Name'] + ' is not added.')
         else:
@@ -464,7 +433,6 @@ def processNetworks(client, userNetworks, hash: str):
         printStatus(None, "")
     publishUpdate(publishCounter, True)
     return mergedNetworksNamesMap
-
 
 
 # processing and adding to server the CheckPoint Ranges
@@ -475,7 +443,7 @@ def processNetworks(client, userNetworks, hash: str):
 # ---
 # returns: mergedRangesNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processRanges(client, userRanges, hash: str):
+def processRanges(client, userRanges):
     printMessageProcessObjects("ranges")
     publishCounter = 0
     mergedRangesNamesMap = {}
@@ -527,10 +495,12 @@ def processRanges(client, userRanges, hash: str):
             printStatus(None, "REPORT: " + "CP object " + mergedRangesNamesMap[
                 userRangeNameInitial] + " is used instead of " + userRangeNameInitial)
         else:
+            userRangeNamePostfix = 1
             if userRange['Name'] in serverRangesMap.values():
                 printStatus(None, None, "More than one object named '" + userRange['Name'] + "' exists.")
                 while userRange['Name'] in serverRangesMap.values():
-                    userRange['Name'] = userRangeNameInitial + '_' + hash
+                    userRange['Name'] = userRangeNameInitial + '_' + str(userRangeNamePostfix)
+                    userRangeNamePostfix += 1
             payload = {
                 "name": userRange['Name'],
                 "ip-address-first": userRange['RangeFrom'],
@@ -539,7 +509,7 @@ def processRanges(client, userRanges, hash: str):
                 "tags": userRange['Tags'],
                 "ignore-warnings": True
             }
-            addedRange = addUserObjectToServer(client, "add-address-range", payload, "")
+            addedRange = addUserObjectToServer(client, "add-address-range", payload, userRangeNamePostfix)
             if addedRange is not None:
                 mergedRangesNamesMap[userRangeNameInitial] = addedRange['name']
                 key = addedRange['ipv4-address-first'] + '_' + addedRange['ipv4-address-last']
@@ -563,7 +533,7 @@ def processRanges(client, userRanges, hash: str):
 # ---
 # returns: mergedGroupsNamesDict dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processNetGroups(client, userNetworkGroups, mergedNetworkObjectsMap, hash: str):
+def processNetGroups(client, userNetworkGroups, mergedNetworkObjectsMap):
     printMessageProcessObjects("network groups")
     publishCounter = 0
     mergedGroupsNamesDict = {}
@@ -587,18 +557,19 @@ def processNetGroups(client, userNetworkGroups, mergedNetworkObjectsMap, hash: s
                     "except": userNetworkGroup['Except'],
                     "comments": userNetworkGroup['Comments'],
                     "tags": userNetworkGroup['Tags']
-                },
-                hash
+                }
             )
         else:
             printStatus(None, "processing network group: " + userNetworkGroup['Name'])
-            addedNetworkGroup = processGroupWithMembers(client, "add-group", userNetworkGroup, False, hash)
+            addedNetworkGroup = processGroupWithMembers(client, "add-group", userNetworkGroup, mergedNetworkObjectsMap,
+                                                        mergedGroupsNamesDict, False)
         if addedNetworkGroup is not None:
             mergedGroupsNamesDict[userNetworkGroupNameInitial] = addedNetworkGroup['name']
             printStatus(None, "REPORT: " + userNetworkGroupNameInitial + " is added as " + addedNetworkGroup['name'])
-            publishCounter = publishUpdate(publishCounter, True)            
+            publishCounter = publishUpdate(publishCounter, True)
             userNetworkGroup["Name"] = addedNetworkGroup['name']
-            processGroupWithMembers(client, "add-group", userNetworkGroup, True, hash)
+            processGroupWithMembers(client, "add-group", userNetworkGroup, mergedNetworkObjectsMap,
+                                    mergedGroupsNamesDict, True)
         else:
             printStatus(None, "REPORT: " + userNetworkGroupNameInitial + " is not added.")
         printStatus(None, "")
@@ -613,14 +584,14 @@ def processNetGroups(client, userNetworkGroups, mergedNetworkObjectsMap, hash: s
 # ---
 # returns: mergedSimpleGatewaysNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processSimpleGateways(client, userSimpleGateways, hash: str):
+def processSimpleGateways(client, userSimpleGateways):
     printMessageProcessObjects("simple gateways")
     publishCounter = 0
     mergedSimpleGatewaysNamesMap = {}
     if len(userSimpleGateways) == 0:
         return mergedSimpleGatewaysNamesMap
     for userSimpleGateway in userSimpleGateways:
-        printStatus(None, "processing simple getway: " + userSimpleGateway['Name'])
+        printStatus(None, "processing simple gateway: " + userSimpleGateway['Name'])
         userSimpleGatewayNameInitial = userSimpleGateway['Name']
         addedSimpleGateway = addUserObjectToServer(
             client,
@@ -630,8 +601,7 @@ def processSimpleGateways(client, userSimpleGateways, hash: str):
                 "ip-address": userSimpleGateway['IpAddress'],
                 "comments": userSimpleGateway['Comments'],
                 "tags": userSimpleGateway['Tags']
-            },
-            hash
+            }
         )
         if addedSimpleGateway is not None:
             mergedSimpleGatewaysNamesMap[userSimpleGatewayNameInitial] = addedSimpleGateway['name']
@@ -651,7 +621,7 @@ def processSimpleGateways(client, userSimpleGateways, hash: str):
 # ---
 # returns: mergedZonesNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processZones(client, userZones, hash: str):
+def processZones(client, userZones):
     printMessageProcessObjects("zones")
     publishCounter = 0
     mergedZonesNamesMap = {}
@@ -667,8 +637,7 @@ def processZones(client, userZones, hash: str):
                 "name": userZone['Name'],
                 "comments": userZone['Comments'],
                 "tags": userZone['Tags']
-            },
-            hash
+            }
         )
         if addedZone is not None:
             mergedZonesNamesMap[userZoneNameInitial] = addedZone['name']
@@ -707,7 +676,7 @@ def provideServerServiceKey(serverService):
 # ---
 # returns: mergedServicesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processServices(client, userServices, userServiceType, hash: str):
+def processServices(client, userServices, userServiceType):
     printMessageProcessObjects(userServiceType + " services")
     publishCounter = 0
     mergedServicesMap = {}
@@ -772,11 +741,13 @@ def processServices(client, userServices, userServiceType, hash: str):
             printStatus(None, "REPORT: " + "CP object " + serverServicesMap[key][
                 0] + " is used instead of " + userServiceNameInitial)
         else:
+            userServiceNamePostfix = 1
             serverServicesNames = [serverServiceNameUid[0] for serverServiceNameUid in serverServicesMap.values()]
             if userService['Name'] in serverServicesNames:
                 printStatus(None, None, "More than one object named '" + userService['Name'] + "' exists.")
                 while userService['Name'] in serverServicesNames:
-                    userService['Name'] = userServiceNameInitial + '_' + hash
+                    userService['Name'] = userServiceNameInitial + '_' + str(userServiceNamePostfix)
+                    userServiceNamePostfix += 1
             payload = {}
             payload["name"] = userService['Name']
             payload["comments"] = userService['Comments']
@@ -794,7 +765,7 @@ def processServices(client, userServices, userServiceType, hash: str):
                 payload["ip-protocol"] = userService['IpProtocol']
                 payload["match-for-any"] = True
             addedService = addUserObjectToServer(client, "add-service-" + userServiceType, payload,
-                                                 "")
+                                                 userServiceNamePostfix)
             if addedService is not None:
                 mergedServicesMap[userServiceNameInitial] = addedService['uid']
                 key = provideServerServiceKey(addedService)
@@ -816,7 +787,7 @@ def processServices(client, userServices, userServiceType, hash: str):
 # ---
 # returns: mergedServicesGroupsNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processServicesGroups(client, userServicesGroups, mergedServicesMap, hash: str):
+def processServicesGroups(client, userServicesGroups, mergedServicesMap):
     printMessageProcessObjects("services groups")
     publishCounter = 0
     mergedServicesGroupsNamesMap = {}
@@ -825,13 +796,15 @@ def processServicesGroups(client, userServicesGroups, mergedServicesMap, hash: s
     for userServicesGroup in userServicesGroups:
         printStatus(None, "processing services group: " + userServicesGroup['Name'])
         userServicesGroupNameInitial = userServicesGroup['Name']
-        addedServicesGroup = processGroupWithMembers(client, "add-service-group", userServicesGroup, False, hash)
+        addedServicesGroup = processGroupWithMembers(client, "add-service-group", userServicesGroup, mergedServicesMap,
+                                                     mergedServicesGroupsNamesMap, False)
         if addedServicesGroup is not None:
             mergedServicesGroupsNamesMap[userServicesGroupNameInitial] = addedServicesGroup['name']
             printStatus(None, "REPORT: " + userServicesGroupNameInitial + " is added as " + addedServicesGroup['name'])
             publishCounter = publishUpdate(publishCounter, True)
             userServicesGroup["Name"] = addedServicesGroup['name']
-            processGroupWithMembers(client, "add-service-group", userServicesGroup, True, hash)
+            processGroupWithMembers(client, "add-service-group", userServicesGroup, mergedServicesMap,
+                                    mergedServicesGroupsNamesMap, True)
         else:
             printStatus(None, "REPORT: " + userServicesGroupNameInitial + " is not added.")
         printStatus(None, "")
@@ -847,7 +820,7 @@ def processServicesGroups(client, userServicesGroups, mergedServicesMap, hash: s
 # ---
 # returns: mergedTimesGroupsNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processTimesGroups(client, userTimesGroups, mergedTimesNamesMap, hash: str):
+def processTimesGroups(client, userTimesGroups, mergedTimesNamesMap):
     printMessageProcessObjects("times groups")
     publishCounter = 0
     mergedTimesGroupsNamesMap = {}
@@ -856,13 +829,15 @@ def processTimesGroups(client, userTimesGroups, mergedTimesNamesMap, hash: str):
     for userTimesGroup in userTimesGroups:
         printStatus(None, "processing times group: " + userTimesGroup['Name'])
         userTimesGroupNameInitial = userTimesGroup['Name']
-        addedTimesGroup = processGroupWithMembers(client, "add-time-group", userTimesGroup, False, hash)
+        addedTimesGroup = processGroupWithMembers(client, "add-time-group", userTimesGroup, mergedTimesNamesMap,
+                                                  mergedTimesGroupsNamesMap, False)
         if addedTimesGroup is not None:
             mergedTimesGroupsNamesMap[userTimesGroupNameInitial] = addedTimesGroup['name']
             printStatus(None, "REPORT: " + userTimesGroupNameInitial + " is added as " + addedTimesGroup['name'])
             publishCounter = publishUpdate(publishCounter, True)
             userTimesGroup["Name"] = addedTimesGroup['name']
-            processGroupWithMembers(client, "add-time-group", userTimesGroup, True, hash)
+            processGroupWithMembers(client, "add-time-group", userTimesGroup, mergedTimesNamesMap,
+                                    mergedTimesGroupsNamesMap, True)
         else:
             printStatus(None, "REPORT: " + userTimesGroupNameInitial + ' is not added.')
         printStatus(None, "")
@@ -877,7 +852,7 @@ def processTimesGroups(client, userTimesGroups, mergedTimesNamesMap, hash: str):
 # ---
 # returns: mergedTimesNamesMap dictionary
 # the map contains name of user's object (key) and name of resulting object (value)
-def processTimes(client, userTimes, hash: str):
+def processTimes(client, userTimes):
     printMessageProcessObjects("times")
     publishCounter = 0
     mergedTimesNamesMap = {}
@@ -942,8 +917,7 @@ def processTimes(client, userTimes, hash: str):
         addedTime = addUserObjectToServer(
             client,
             "add-time",
-            payload,
-            hash
+            payload
         )
 
         if addedTime is not None:
@@ -969,7 +943,7 @@ def processTimes(client, userTimes, hash: str):
 # ---
 # returns: nothing
 def addAccessRules(client, userRules, userLayerName, skipCleanUpRule, mergedNetworkObjectsMap, mergedServiceObjectsMap,
-                   mergedTimesGroupsNamesMap, mergedTimesNamesMap, hash: str):
+                   mergedTimesGroupsNamesMap, mergedTimesNamesMap):
     if userRules is not None:
         publishCounter = 0
         printStatus(None, "processing access rules to " + userLayerName + " layer")
@@ -1040,7 +1014,7 @@ def addAccessRules(client, userRules, userLayerName, skipCleanUpRule, mergedNetw
                 payload["inline-layer"] = userRule['SubPolicyName']
             if userRule['ConversionComments'].strip() != "":
                 payload["custom-fields"] = {"field-1": userRule['ConversionComments']}
-            addedRule = addUserObjectToServer(client, "add-access-rule", payload,  hash, changeName=False)
+            addedRule = addUserObjectToServer(client, "add-access-rule", payload, changeName=False)
             if addedRule is not None:
                 printStatus(None, "REPORT: access rule is added")
                 publishCounter = publishUpdate(publishCounter, False)
@@ -1059,7 +1033,7 @@ def addAccessRules(client, userRules, userLayerName, skipCleanUpRule, mergedNetw
 # ---
 # returns: added package in JSON format
 def processPackage(client, userPackage, mergedNetworkObjectsMap, mergedServiceObjectsMap, mergedTimesGroupsNamesMap,
-                   mergedTimesNamesMap, hash: str):
+                   mergedTimesNamesMap):
     printMessageProcessObjects("package")
     allExistingLayers = {}
     addedPackage = None
@@ -1076,7 +1050,6 @@ def processPackage(client, userPackage, mergedNetworkObjectsMap, mergedServiceOb
                 "threat-prevention": False,
                 "tags": userPackage['Tags']
             },
-            hash,
             changeName=False
         )
         if addedPackage is None:
@@ -1106,7 +1079,6 @@ def processPackage(client, userPackage, mergedNetworkObjectsMap, mergedServiceOb
                         "comments": userSubLayer['Comments'],
                         "tags": userSubLayer['Tags']
                     },
-                    hash,
                     changeName=False
                 )
                 if addedSubLayer is None:
@@ -1116,16 +1088,18 @@ def processPackage(client, userPackage, mergedNetworkObjectsMap, mergedServiceOb
                 printStatus(None, "")
                 publishCounter = publishUpdate(publishCounter, True)
                 addAccessRules(client, userSubLayer['Rules'], userSubLayer['Name'], False, mergedNetworkObjectsMap,
-                               mergedServiceObjectsMap, mergedTimesGroupsNamesMap, mergedTimesNamesMap, hash)
+                               mergedServiceObjectsMap, mergedTimesGroupsNamesMap, mergedTimesNamesMap)
         if userPackage['ParentLayer'] is not None:
-            userPackage['ParentLayer']['Name'] = userPackage['ParentLayer']['Name'].replace(original_package_name, userPackage['Name'])
+            userPackage['ParentLayer']['Name'] = userPackage['ParentLayer']['Name'].replace(original_package_name,
+                                                                                            userPackage['Name'])
             for parentRule in userPackage['ParentLayer']['Rules']:
                 parentRule['Layer'] = userPackage['ParentLayer']['Name']
                 if parentRule['SubPolicyName'] != "":
                     parentRule['SubPolicyName'] = allExistingLayers[parentRule['SubPolicyName']]
             addAccessRules(client, userPackage['ParentLayer']['Rules'], "parent", True, mergedNetworkObjectsMap,
-                           mergedServiceObjectsMap, mergedTimesGroupsNamesMap, mergedTimesNamesMap, hash)
+                           mergedServiceObjectsMap, mergedTimesGroupsNamesMap, mergedTimesNamesMap)
     return addedPackage
+
 
 # resolver for nat method type
 # typeValue - number of type [ static, hide, nat64, nat46 ]
@@ -1139,6 +1113,7 @@ def getMethodType(typeValue):
         _type = "nat46"
     return _type
 
+
 # processing and adding to server the CheckPoint NAT rules
 # NAT rules are added if package has been added
 # client - client object
@@ -1148,7 +1123,7 @@ def getMethodType(typeValue):
 # mergedServiceObjectsMap - map of all services objects (groups is included) which will be used for replacing
 # ---
 # returns: nothing
-def processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap, mergedServiceObjectsMap, hash: str):
+def processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap, mergedServiceObjectsMap):
     printMessageProcessObjects("nat rules")
     if addedPackage is None:
         printStatus(None, "REPORT: nat rules can not been added because package was not added")
@@ -1199,7 +1174,7 @@ def processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap,
             "translated-destination": destinationTrans,
             "translated-service": serviceTrans
         }
-        addedNatRule = addUserObjectToServer(client, "add-nat-rule", payload, hash, changeName=False)
+        addedNatRule = addUserObjectToServer(client, "add-nat-rule", payload, changeName=False)
         if addedNatRule is not None:
             printStatus(None, "REPORT: nat rule is added")
             publishCounter = publishUpdate(publishCounter, False)
@@ -1209,18 +1184,7 @@ def processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap,
     publishCounter = publishUpdate(publishCounter, True)
 
 
-def generateHash(symb_count: int) -> str:
-    return ''.join(random.choices(string.ascii_uppercase + string.digits, k = symb_count))
-
 # START
-
-first_period = time.time()
-start_time = time.localtime()
-start_time_str = time.strftime("%H:%M:%S", start_time)
-with open("timelog.txt", "at") as timelog:
-    timelog.write("\n\nStart\n")
-    timelog.write(start_time_str)
-
 
 args_parser = argparse.ArgumentParser()
 
@@ -1232,11 +1196,11 @@ args_parser.add_argument('--port', type=int,
                          help="Server port. Default: 443")
 mxg = args_parser.add_mutually_exclusive_group(required=True)
 mxg.add_argument('-r', '--root', action="store_true",
-                         help="For a logged in administrator that wants to receive SuperUser permissions. Additional login credentials are not required.")
+                 help="For a logged in administrator that wants to receive SuperUser permissions. Additional login credentials are not required.")
 mxg.add_argument('-k', '--key',
-                         help="api_key")
+                 help="api_key")
 mxg.add_argument('-u', '--user',
-                         help="User name")
+                 help="User name")
 args_parser.add_argument('-p', '--password',
                          help="User password")
 args_parser.add_argument('-f', '--file', default='cp_objects.json',
@@ -1287,7 +1251,6 @@ elif args.replace_from_global_first.lower() != "true" and args.replace_from_glob
     print("")
     args_parser.print_help()
 else:
-    isReplaceFromGlobalFirst = None
     if args.replace_from_global_first.lower() == "true":
         isReplaceFromGlobalFirst = True
     elif args.replace_from_global_first.lower() == "false":
@@ -1337,8 +1300,7 @@ else:
             userNetworks.append(jsonObject)
         if jsonObject['TypeName'] == 'CheckPoint_Range':
             userRanges.append(jsonObject)
-        if jsonObject['TypeName'] == 'CheckPoint_NetworkGroup' or jsonObject[
-            'TypeName'] == 'CheckPoint_GroupWithExclusion':
+        if jsonObject['TypeName'] == 'CheckPoint_NetworkGroup' or jsonObject['TypeName'] == 'CheckPoint_GroupWithExclusion':
             userNetGroups.append(jsonObject)
         if jsonObject['TypeName'] == 'CheckPoint_SimpleGateway':
             userSimpleGateways.append(jsonObject)
@@ -1407,43 +1369,27 @@ else:
                 printStatus(None, "Login failed: {}".format(login_res.error_message))
             else:
                 printStatus(None, "")
-
-                hash = generateHash(10)
-
                 mergedNetworkObjectsMap = {}
-                mergedNetworkObjectsMap.update(processDomains(client, userDomains, hash))
-                mergedNetworkObjectsMap.update(processHosts(client, userHosts, hash))
-                mergedNetworkObjectsMap.update(processNetworks(client, userNetworks, hash))
-                mergedNetworkObjectsMap.update(processRanges(client, userRanges, hash))
-                mergedNetworkObjectsMap.update(processNetGroups(client, userNetGroups, mergedNetworkObjectsMap, hash))
-                mergedNetworkObjectsMap.update(processSimpleGateways(client, userSimpleGateways, hash))
-                mergedNetworkObjectsMap.update(processZones(client, userZones, hash))
+                mergedNetworkObjectsMap.update(processDomains(client, userDomains))
+                mergedNetworkObjectsMap.update(processHosts(client, userHosts))
+                mergedNetworkObjectsMap.update(processNetworks(client, userNetworks))
+                mergedNetworkObjectsMap.update(processRanges(client, userRanges))
+                mergedNetworkObjectsMap.update(processNetGroups(client, userNetGroups, mergedNetworkObjectsMap))
+                mergedNetworkObjectsMap.update(processSimpleGateways(client, userSimpleGateways))
+                mergedNetworkObjectsMap.update(processZones(client, userZones))
                 mergedServicesObjectsMap = {}
-                mergedServicesObjectsMap.update(processServices(client, userServicesTcp, "tcp", hash))
-                mergedServicesObjectsMap.update(processServices(client, userServicesUdp, "udp", hash))
-                mergedServicesObjectsMap.update(processServices(client, userServicesSctp, "sctp", hash))
-                mergedServicesObjectsMap.update(processServices(client, userServicesIcmp, "icmp", hash))
-                mergedServicesObjectsMap.update(processServices(client, userServicesOther, "other", hash))
+                mergedServicesObjectsMap.update(processServices(client, userServicesTcp, "tcp"))
+                mergedServicesObjectsMap.update(processServices(client, userServicesUdp, "udp"))
+                mergedServicesObjectsMap.update(processServices(client, userServicesSctp, "sctp"))
+                mergedServicesObjectsMap.update(processServices(client, userServicesIcmp, "icmp"))
+                mergedServicesObjectsMap.update(processServices(client, userServicesOther, "other"))
                 mergedServicesObjectsMap.update(
-                    processServicesGroups(client, userServicesGroups, mergedServicesObjectsMap, hash))
-                mergedTimesMap = processTimes(client, userTimes, hash)
-                mergedTimesGroupsMap = processTimesGroups(client, userTimesGroups, mergedTimesMap, hash)
+                    processServicesGroups(client, userServicesGroups, mergedServicesObjectsMap))
+                mergedTimesMap = processTimes(client, userTimes)
+                mergedTimesGroupsMap = processTimesGroups(client, userTimesGroups, mergedTimesMap)
                 addedPackage = processPackage(client, userPackage, mergedNetworkObjectsMap, mergedServicesObjectsMap,
-                                              mergedTimesGroupsMap, mergedTimesMap, hash)
-                processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap, mergedServicesObjectsMap, hash)
+                                              mergedTimesGroupsMap, mergedTimesMap)
+                processNatRules(client, addedPackage, userNatRules, mergedNetworkObjectsMap, mergedServicesObjectsMap)
                 printStatus(None, "==========")
-
-
-with open("timelog.txt", "at") as timelog:
-    t = time.localtime()
-    second_period = time.time()
-
-    current_time = time.strftime("%H:%M:%S", t)
-
-    timelog.write("\nFinish\n")
-    timelog.write(current_time)
-    timelog.write("\nTotal\n")
-    timelog.write(str(second_period - first_period))
-
 file_log.close()
 # END


### PR DESCRIPTION
- In console app and in UI was added a new vendor: **FirePower** with ASA syntax
- In optimized rules file was fixed an issue with comments - currently it works correct
- To console app was added hidden flag  **--asa-spread-acl-remarks**. This allows the import of comments in a Cisco configuration to be applied to multiple access control entries. Without this flag, Smartmove would only apply the comment to the first imported rule. This creates a situation where all rules have comments stating which change control request was used to make the policy change.
Usage:
`SmartMove.exe  -s "D:\config.conf" -v CiscoASA -t E:\cp --asa-spread-acl-remarks true|false`
