### PR TITLE
Only map network objects matching subnet and mask

### DIFF
--- a/SmartMove/SmartConnector/smartconnector.py
+++ b/SmartMove/SmartConnector/smartconnector.py
@@ -190,10 +190,10 @@ def addCpObjectWithIpToServer(client, payload, userObjectType, userObjectIp, mer
                 printStatus(res_get_obj_with_ip, None)
                 if res_get_obj_with_ip.success is True:
                     if len(res_get_obj_with_ip.data) > 0:
-                        if userObjectType == "network" and next((x for x in res_get_obj_with_ip.data if x['subnet4' if is_valid_ipv4(payload['subnet']) else 'subnet6'] == payload['subnet']), None) is None:
+                        if userObjectType == "network" and next((x for x in res_get_obj_with_ip.data if x['subnet4' if is_valid_ipv4(payload['subnet']) else 'subnet6'] == payload['subnet'] and (x['subnet-mask'] == payload['subnet-mask']) if is_valid_ipv4(payload['subnet'])), None) is None:
                             isIgnoreWarnings = True
                         else:
-                            if userObjectType == "host" or userObjectType == "network":
+                            if userObjectType == "host":
                                 mergedObjectsNamesMap[userObjectNameInitial] = res_get_obj_with_ip.data[0]['name']
                                 printStatus(None, "REPORT: " + "CP object " + mergedObjectsNamesMap[
                                     userObjectNameInitial] + " is used instead of " + userObjectNameInitial)
@@ -201,7 +201,7 @@ def addCpObjectWithIpToServer(client, payload, userObjectType, userObjectIp, mer
                                 break
                             for serverObject in res_get_obj_with_ip.data:
                                 # if more then one network in res_get_obj_with_ip, map to the one that matches subnet
-                                mergedObjectsNamesMap[userObjectNameInitial] = next((x['name'] for x in res_get_obj_with_ip.data if x['subnet4' if is_valid_ipv4(payload['subnet']) else 'subnet6'] == payload['subnet']))
+                                mergedObjectsNamesMap[userObjectNameInitial] = next(x['name'] for x in res_get_obj_with_ip.data if x['subnet4' if is_valid_ipv4(payload['subnet']) else 'subnet6'] == payload['subnet'] and (x['subnet-mask'] == payload['subnet-mask']) if is_valid_ipv4(payload['subnet']))
                                 if (isServerObjectLocal(serverObject) and not isReplaceFromGlobalFirst) or (
                                         isServerObjectGlobal(serverObject) and isReplaceFromGlobalFirst):
                                     break


### PR DESCRIPTION
Change to how network objects are mapped to make sure subnets are not inadvertently mapped to wider supernets.



I found an issue with the mapping of networks where a subnet will be mapped to a larger supernet if appears in the search result list before the subnet.

The debug output shows:

  processing network: network_172.24.47.160_29
WARN: More than one object named 'network_172.24.47.160_29' exists.
WARN: More than one network has the same IP 172.24.47.160/255.255.255.248
  REPORT: CP object network_172.16.0.0_12 is used instead of network_172.24.47.160_29
 
You can see a /29 subnet is mapped to a /12, which is undesirable.
 
I have submitted a pull request for a fix that I have tested on an import form a Cisco ASA
It adds an extra condition to match on both subnet and subnet-mask