### PR TITLE
fix issue with converting large files

### DIFF
--- a/MigrationBase/VendorConverter.cs
+++ b/MigrationBase/VendorConverter.cs
@@ -2170,7 +2170,17 @@ namespace MigrationBase
                 cpJsonObjects.RemoveAll(x => x == null);
                 #endregion
 
-                File.WriteAllText(cpObjectsJsonPath + cpObjectsJsonFN, JsonConvert.SerializeObject(cpJsonObjects, Formatting.Indented));
+                if (cpJsonObjects.Count > 250000)
+                {
+                    File.WriteAllText(cpObjectsJsonPath + cpObjectsJsonFN, JsonConvert.SerializeObject(cpJsonObjects[0], Formatting.Indented));
+
+                    for (var i = 1; i < cpJsonObjects.Count;)
+                    {
+                        var dest = cpJsonObjects.Skip(i).Take(250000).ToArray();
+                        i += 250000;
+                        File.AppendAllText(cpObjectsJsonPath + cpObjectsJsonFN, JsonConvert.SerializeObject(dest, Formatting.Indented));
+                    }
+                } else File.WriteAllText(cpObjectsJsonPath + cpObjectsJsonFN, JsonConvert.SerializeObject(cpJsonObjects, Formatting.Indented));
 
                 string smartConnectorArchiveName = "smartconnector_" + _vendorFileName;
                 string smartConnectorArchivePath = _targetFolder + Path.DirectorySeparatorChar + smartConnectorArchiveName;

--- a/SmartMove/AnalyzeWindow.xaml.cs
+++ b/SmartMove/AnalyzeWindow.xaml.cs
@@ -335,6 +335,12 @@ namespace SmartMove
                                                 "Reason: Policy exceeds the maximum number of supported policy layers.",
                                                 "To assure the smooth conversion of your data, it is recommended to contact Check Point Professional Services by sending an e-mail to"));
                 }
+                else if (ex.Message.Contains("System.OutOfMemoryException"))
+                {
+                    MainWindow.ShowMessage(null, MessageTypes.Error, null, null, null, null,
+                        String.Format("{1}{0}{2}", Environment.NewLine, "Could not analyze process file.",
+                                                "Reason: Your device is low on memory."));
+                }
                 else
                 {
                     MainWindow.ShowMessage("Could not analyze process file.", "Message:\nModule:\nClass:\nMethod:", string.Format("{0}\n{1}\n{2}\n{3}", ex.Message, ex.Source, ex.TargetSite.ReflectedType.Name, ex.TargetSite.Name), MessageTypes.Error);

--- a/SmartMove/MainWindow.xaml.cs
+++ b/SmartMove/MainWindow.xaml.cs
@@ -765,6 +765,12 @@ namespace SmartMove
                 }
                 else
                 {
+                    if (ex.Message.Contains("System.OutOfMemoryException"))
+                    {
+                        ShowMessage(null, MessageTypes.Error, null, null, null, null,
+                            String.Format("{1}{0}{2}", Environment.NewLine, "Could not convert configuration file.",
+                                                    "Reason: Your device is low on memory."));
+                    } else 
                     ShowMessage("Could not convert configuration file.", "Message:\nModule:\nClass:\nMethod:", string.Format("{0}\n{1}\n{2}\n{3}", ex.Message, ex.Source, ex.TargetSite.ReflectedType.Name, ex.TargetSite.Name), MessageTypes.Error);
                 }
                 return;


### PR DESCRIPTION
changed to the optimal number of elements at a time
it writes 250,000 checkpoint objects at a time, with files containing more than 250,000 checkpoint objects
As a result, everything is converted 
(and it takes ~ 9 minutes if it is a very large file)