### PR TITLE
Cisco fix: optimize MatchNATRulesIntoFirewallPolicy

### DIFF
--- a/CiscoMigration/CiscoConverter.cs
+++ b/CiscoMigration/CiscoConverter.cs
@@ -5268,10 +5268,6 @@ namespace CiscoMigration
                                     {
                                         break;
                                     }
-                                    else
-                                    {
-                                        ++ruleNumber;   // this is because we are changing the collection during iteration!!!
-                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
the MatchNATRulesIntoFirewallPolicy() function process has been threaded for all _cpNatRules
During threads, no data is changed, and new rules are added to a separate array
and after the completion of the threads, new rules from the array(duplicates are removed) are added